### PR TITLE
Use different port for second lb

### DIFF
--- a/resource-manifests/service-sa-web-app-lb.yaml
+++ b/resource-manifests/service-sa-web-app-lb.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   type: LoadBalancer
   ports:
-  - port: 80
+  - port: 8080
     protocol: TCP
     targetPort: 8080
   selector:


### PR DESCRIPTION
Both the load balancers are exposed at port 80 on the host machine. Hence, the external IP for web-app-lb gets stuck in a pending state. Exposing the second LB to a port other than 80 solved the problem.