### PR TITLE
remove unnecessary protocol

### DIFF
--- a/resource-manifests/service-sa-logic.yaml
+++ b/resource-manifests/service-sa-logic.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   ports:
     - port: 80
-      protocol: TCP
       targetPort: 5000
   selector:
     app: sa-logic


### PR DESCRIPTION
TCP is the default protocol

https://kubernetes.io/docs/concepts/services-networking/service/

"The default protocol for Services is TCP; you can also use any other supported protocol."