### PR TITLE
Pin Werkzeug dependency version to fix JSON error when pulling latest version

### DIFF
--- a/sa-logic/sa/requirements.txt
+++ b/sa-logic/sa/requirements.txt
@@ -1,2 +1,3 @@
+Werkzeug==0.16.1
 Flask==0.12.2
 textblob==0.15.0


### PR DESCRIPTION
# Why? 

I was working through the exercises, and the python app was failing on every request with the following error:

>  AttributeError: 'Request' object has no attribute 'is_xhr'

The root of the issue is discussed here: https://github.com/pallets/flask/issues/2549#issuecomment-583377526

# What changed? 

Forcing version Werkzeug to use version 0.16.1 in the python app's requirements.txt file fixed it. 

# Thanks!

Thanks for the guide and the repository, it's a terrific resource!