### PR TITLE
Fix to an issue causing unable to execute 'gcc'

### DIFF
--- a/sa-logic/Dockerfile
+++ b/sa-logic/Dockerfile
@@ -1,4 +1,7 @@
 FROM python:3.6.6-alpine
+RUN apk update
+RUN apk add musl-dev
+RUN apk add --update gcc
 COPY sa /app
 WORKDIR /app
 RUN pip3 install -r requirements.txt && \


### PR DESCRIPTION
An issue is observed when running or creating a container image for sa-logic app throwing the below error:
/usr/local/include/python3.6m/Python.h:11:20: fatal error: limits.h: No such file or directory
   #include <limits.h>
                      ^
  compilation terminated.
  error: command 'gcc' failed with exit status 1
  
  ----------------------------------------
  Failed building wheel for regex
